### PR TITLE
Make kdress script python3-compatible

### DIFF
--- a/kdress
+++ b/kdress
@@ -4,7 +4,7 @@ import os
 import subprocess
 
 if (len(sys.argv) < 4):
-	print 'Usage: ./kdress <vmlinuz> <vmlinux> <System.map>\n'
+	print('Usage: ./kdress <vmlinuz> <vmlinux> <System.map>\n')
 	sys.exit(-1)
 
 subprocess.call(['./kunpress', sys.argv[1], sys.argv[2]])


### PR DESCRIPTION
By default there is no python2 in Ubuntu 16.04. User could at least run kdress without installing python2 like this:

```
python3 ./kdress <arguments>
```

But currently it's not possible.
